### PR TITLE
1003: Changed dice functionality to allow changes to dice min and max

### DIFF
--- a/server/src/model/game/action/attack.ts
+++ b/server/src/model/game/action/attack.ts
@@ -5,12 +5,16 @@ import socket from "../../socket";
 
 export class AttackAction extends Action {
   private attackBonus: number;
-  private damage: number;
-  private d20: number;
+  private damage: number = 0;
+  private d20: number = 0;
+  private diceMin: number;
+  private diceMax: number;
 
-  constructor(attackBonus: number) {
+  constructor(attackBonus: number, diceMin: number = 1, diceMax: number = 20) {
     super(ActionIdentifier.ATTACK, "Attack", "Attack an enemy", Infinity);
     this.attackBonus = attackBonus;
+    this.diceMin = diceMin;
+    this.diceMax = diceMax;
   }
 
   public getDamage(): number {
@@ -18,7 +22,11 @@ export class AttackAction extends Action {
   }
 
   private rollDice(): number {
-    var d20 = Math.floor(Math.random() * 20);
+    // Determine the range of the dice roll
+    const range = this.diceMax - this.diceMin + 1;
+
+    // Generate a number within the range size, then add the minimum value to bring it within the actual range
+    const d20 = Math.floor(Math.random() * range) + this.diceMin;
     console.log(`Dice roll: ${d20}`);
     return d20;
   }


### PR DESCRIPTION
# Description

Hey guys, this is a short one. Basically the dragon's ability Elemental Breath was originally meant to give you another roll to increase your odds of landing a hit. Since it's a bit difficult to do that based on our current back-end, we've modified the definition to instead 'rig' the dice into giving you a better chance to land the attack the first time, rather than giving you another chance.

Note: This change did NOT update how the visual dice looks when it's rolling (it still cycles between 0-20 regardless of the range on the actual backend dice roll). Might be good to look into for a future update

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested without inputs in the constructor of AttackAction(), and with (see monster.ts constructor). Double-checked with Huu to ensure this is what we want.

- [ ] End-to-end tests w/ Playwright
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] CI Pipeline
- [x] Manual Testing (please describe if checked):
- [ ] N/A

# Checklist (only check off the applicable):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
