### PR TITLE
1004: Add critical hits to the game

### DIFF
--- a/client/src/components/buttons/ActionButton.tsx
+++ b/client/src/components/buttons/ActionButton.tsx
@@ -17,6 +17,7 @@ const ActionButton: React.FC<ActionButtonProps> = ({ actionState, battleId, isAc
     const imagePath = "/assets/actions/" + actionState.id + ".png";
     const name = actionState.name.toUpperCase();
     const availableUses = actionState.currentUse; // How many REMAINING uses
+    const isPassive = actionState.maxUse == 0; // Action is a passive ability if it can't be used
 
     const colorLoader: Record<string, ButtonGenericProps["color"]> = {
         [ActionIdentifier.ATTACK]: 'red',
@@ -48,7 +49,7 @@ const ActionButton: React.FC<ActionButtonProps> = ({ actionState, battleId, isAc
 
     return(
         <div className="relative group">
-        <ButtonGeneric color={colorLoader[actionState.id] ?? 'purple'} size='battle' isDisabled={isDisabled} onClick={allClickHandlers}>
+        <ButtonGeneric color={colorLoader[actionState.id] ?? 'purple'} size='battle' isDisabled={isDisabled} onClick={allClickHandlers} isPassive={isPassive}>
             <div className="w-[50%] h-auto leading-[0.8]">
                 { (name === "ATTACK" || name === "DEFEND")
                 ? (<OutlineText size="medium">{name}</OutlineText>)
@@ -58,7 +59,7 @@ const ActionButton: React.FC<ActionButtonProps> = ({ actionState, battleId, isAc
             <img className = {`${image} rounded-md`} src={`${imagePath}`} alt={`${actionState.id} image`}/>
         </ButtonGeneric>
 
-        {availableUses != null && (
+        {availableUses != null && !isPassive && (
             <div className={`
                 absolute
                 top-14

--- a/client/src/components/buttons/ButtonGeneric.tsx
+++ b/client/src/components/buttons/ButtonGeneric.tsx
@@ -6,10 +6,11 @@ export interface ButtonGenericProps{
 	isDisabled?: boolean;
 	children?: ReactNode
 	onClick?: () => void;
-	mobileHidden?: 'false' | 'true' 
+	mobileHidden?: 'false' | 'true'
+	isPassive?: boolean;
 }
 
-export const ButtonGeneric = ({color,size,isDisabled,children,onClick,mobileHidden='false'}: ButtonGenericProps) => {
+export const ButtonGeneric = ({color,size,isDisabled,children,onClick,mobileHidden='false',isPassive=false}: ButtonGenericProps) => {
 
 	const colorToDisplay = {
 		'ronchi': 'bg-ronchi',
@@ -41,7 +42,6 @@ export const ButtonGeneric = ({color,size,isDisabled,children,onClick,mobileHidd
 		items-center
 		justify-around
 		text-merino
-		outline-blackCurrant
 		sm:outline-[0.75rem]
 		md:outline-[0.5rem]
 		lg:outline-[0.25rem]
@@ -59,20 +59,28 @@ export const ButtonGeneric = ({color,size,isDisabled,children,onClick,mobileHidd
 		active:outline-blackCurrant
 		active:ring-[0.3125rem]
 		active:ring-blackCurrant
+		outline-blackCurrant
 		`;
 
 	const disabledButton = 
 		`
 		grayscale
 		cursor-not-allowed 
+		outline-blackCurrant
 		`;
+
+	const passiveButton = 
+		`
+		outline-[#43bf37]
+		cursor-not-allowed
+		`
 
     return(
 		<button
 		disabled={isDisabled}
 		className={`
-			${baseButton} 
-			${isDisabled ? disabledButton : enabledButton}
+			${baseButton}
+			${isDisabled ? (isPassive ? passiveButton : disabledButton) : enabledButton}
 			${sizeToDisplay[size]}
 		`}
 		onClick={onClick}> 

--- a/client/src/pages/Game/WinnerScreen.tsx
+++ b/client/src/pages/Game/WinnerScreen.tsx
@@ -54,62 +54,6 @@ const WinnerScreen: React.FC<WinningScreenProps> = ({playerMonster}) => {
     )
   }
 
-import React, { useEffect, useState } from "react";
-import socket from "../../socket";
-import { FlowRouter } from "meteor/ostrio:flow-router-extra";
-import { BlankPage } from "../../components/pagelayouts/BlankPage";
-import { GenericHeader } from "../../components/cards/GenericHeader";
-import { OutlineText } from "../../components/texts/OutlineText";
-import { BaseCard } from "../../components/cards/BaseCard";
-import { ButtonGeneric } from "../../components/buttons/ButtonGeneric";
-import { MonsterState } from "/types/single/monsterState";
-
-interface WinningScreenProps {
-  playerMonster: MonsterState|null;
-}
-
-const WinnerScreen: React.FC<WinningScreenProps> = ({playerMonster}) => {
-
-  socket.on("kick-warning", ({ message }) => {
-    console.log(message);
-    // UPDATE: add pop up when kicked
-    FlowRouter.go("/");
-  });
-
-  const leave = () => {
-    socket.emit('leave-game', {userID:socket.id})
-    FlowRouter.go("/")
-  };
-
-  // const leave = () => {
-  //   socket.emit('leave-game', {userID:socket.id})
-  //   FlowRouter.go("/")
-  // };
-
-  if (!playerMonster) {
-    return (
-    <BlankPage >
-      <div className='w-115 h-30'>
-        <div className='items-center'>
-          <OutlineText size="medium">ERROR PLEASE RETURN TO HOME</OutlineText>
-        </div>
-      </div>
-      <ButtonGeneric
-        color="red"
-        size="medium"
-        onClick={() => leave()}
-      >
-        <div className="flex flex-row items-center justify-around w-full h-full space-x-3">
-          <div>
-            <OutlineText size="medium">EXIT LOBBY</OutlineText>
-          </div>
-        </div>
-      </ButtonGeneric>
-
-    </BlankPage>
-    )
-  }
-
   return (
     // <div>
     //   You won!

--- a/server/src/model/game/action/ability/feralStrike.ts
+++ b/server/src/model/game/action/ability/feralStrike.ts
@@ -2,7 +2,7 @@ import { Action } from "../action";
 import { Player } from "../../player";
 import { ActionIdentifier } from "/types/single/actionState";
 
-export class FeralStrikePassive extends Action {
+export class FeralStrikeAbilityPassive extends Action {
   constructor() {
     super(
       ActionIdentifier.FERAL_STRIKE,

--- a/server/src/model/game/action/ability/feralStrike.ts
+++ b/server/src/model/game/action/ability/feralStrike.ts
@@ -2,24 +2,17 @@ import { Action } from "../action";
 import { Player } from "../../player";
 import { ActionIdentifier } from "/types/single/actionState";
 
-export class FeralStrikeAbilityAction extends Action {
+export class FeralStrikePassive extends Action {
   constructor() {
     super(
       ActionIdentifier.FERAL_STRIKE,
       "Feral Strike",
-      "Deals extra damage on critical hits.",
-      Infinity
+      "Increases your critical hit rate by 15%.",
+      0 // Passive abilities do not have uses
     );
   }
 
   public prepare(actingPlayer: Player, affectedPlayer: Player): void {}
 
-  public execute(actingPlayer: Player, affectedPlayer: Player): void {
-    actingPlayer.addLog(
-      `You did nothing. Unimplemented action ${this.getName()}`
-    );
-    affectedPlayer.addLog(
-      `${actingPlayer.getName()} did nothing. Unimplemented action ${this.getName()}`
-    );
-  }
+  public execute(actingPlayer: Player, affectedPlayer: Player): void {}
 }

--- a/server/src/model/game/archetype/archetype.ts
+++ b/server/src/model/game/archetype/archetype.ts
@@ -5,9 +5,12 @@ export abstract class Archetype {
 
   private ability: Action;
 
-  constructor(name: string, ability: Action) {
+  private critRate: number; // Monsters have a default crit rate of 10%
+
+  constructor(name: string, ability: Action, critRate: number = 10) {
     this.ability = ability;
     this.name = name;
+    this.critRate = critRate;
   }
 
   public getName(): string {
@@ -16,5 +19,9 @@ export abstract class Archetype {
 
   public getAbility(): Action {
     return this.ability;
+  }
+
+  public getCritRate(): number {
+    return this.critRate;
   }
 }

--- a/server/src/model/game/archetype/warrior.ts
+++ b/server/src/model/game/archetype/warrior.ts
@@ -1,8 +1,8 @@
 import { Archetype } from "./archetype";
-import { FeralStrikeAbilityAction } from "../action/ability/feralStrike";
+import { FeralStrikePassive } from "../action/ability/feralStrike";
 
 export class Warrior extends Archetype {
   constructor() {
-    super("Warrior", new FeralStrikeAbilityAction());
+    super("Warrior", new FeralStrikePassive(), 25); // Warrior-type monsters have an enhanced crit rate of 25%
   }
 }

--- a/server/src/model/game/archetype/warrior.ts
+++ b/server/src/model/game/archetype/warrior.ts
@@ -1,8 +1,8 @@
 import { Archetype } from "./archetype";
-import { FeralStrikePassive } from "../action/ability/feralStrike";
+import { FeralStrikeAbilityPassive } from "../action/ability/feralStrike";
 
 export class Warrior extends Archetype {
   constructor() {
-    super("Warrior", new FeralStrikePassive(), 25); // Warrior-type monsters have an enhanced crit rate of 25%
+    super("Warrior", new FeralStrikeAbilityPassive(), 25); // Warrior-type monsters have an enhanced crit rate of 25%
   }
 }

--- a/server/src/model/game/monster/monster.ts
+++ b/server/src/model/game/monster/monster.ts
@@ -4,6 +4,7 @@ import { AttackAction } from "../action/attack";
 import { DefendAction } from "../action/defend";
 import { MonsterIdentifier, MonsterState } from "/types/single/monsterState";
 import { ActionIdentifier, ActionState } from "/types/single/actionState";
+import { arch } from "os";
 
 export abstract class Monster {
   private id: MonsterIdentifier;
@@ -18,6 +19,7 @@ export abstract class Monster {
   private maxHealth: number;
   private attackBonus: number;
   private armourClass: number;
+  private critRate: number;
 
   constructor(
     id: MonsterIdentifier,
@@ -36,7 +38,9 @@ export abstract class Monster {
     this.maxHealth = maxHealth;
     this.attackBonus = attackBonus;
     this.armourClass = armourClass;
-    this.possibleActions.push(new AttackAction(attackBonus));
+    this.critRate = archetype.getCritRate();
+
+    this.possibleActions.push(new AttackAction(attackBonus, this.critRate));
     this.possibleActions.push(new DefendAction(armourClass));
     this.possibleActions.push(ability);
     this.possibleActions.push(archetype.getAbility());

--- a/server/src/model/game/monster/monster.ts
+++ b/server/src/model/game/monster/monster.ts
@@ -4,7 +4,6 @@ import { AttackAction } from "../action/attack";
 import { DefendAction } from "../action/defend";
 import { MonsterIdentifier, MonsterState } from "/types/single/monsterState";
 import { ActionIdentifier, ActionState } from "/types/single/actionState";
-import { arch } from "os";
 
 export abstract class Monster {
   private id: MonsterIdentifier;


### PR DESCRIPTION
# Description

Critical hits are here! All monsters are now capable of dealing a critical hit, doubling their damage. The base crit rate for all monsters is 10%, but Warrior monsters (currently only Pouncing Bandit) have an enhanced crit rate of 25%.
- Also fixed an issue with the winner screen, not sure how that happened

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tried it in game and it worked. Also used a calculator to double check that my crit checks were correct.

- [ ] End-to-end tests w/ Playwright
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] CI Pipeline
- [x] Manual Testing (please describe if checked):
- [ ] N/A

# Checklist (only check off the applicable):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
