### PR TITLE
Bugfix/3010 adventure popup uplift

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,20 +154,31 @@ There are four GitHub Actions Workflows to manage application deployment.
 
 <div align="center">
 
+### Roles
+
+| Emoji | Role                   |
+| :---: | ---------------------- |
+|  🧑‍💼   | Product Manager        |
+|  🚂   | Release Train Engineer |
+|  🏗️   | System Architect       |
+
+</div>
+
+<div align="center">
   <div style="display:inline-block; width:280px; margin:20px; vertical-align:top; text-align:center;">
     <img src="https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/character/CHARMER_COBRA.png" alt="Team Cobra" width="200" />
     <h3>Team Cobra</h3>
     <table align="center" style="border-collapse:collapse;">
       <tr>
-        <td><strong>Naveen</strong><br><small>nsel0009@student.monash.edu</small></td>
-        <td><strong>Huu Nguyen</strong><br><small>hngu0187@student.monash.edu</small></td>
+        <td><strong>🚂 Luna</strong><br><small>pnag0009@student.monash.edu</small></td>
+        <td><strong>🚂 Huu Nguyen</strong><br><small>hngu0187@student.monash.edu</small></td>
       </tr>
       <tr>
-        <td><strong>Danniel</strong><br><small>dyou0009@student.monash.edu</small></td>
-        <td><strong>Luna</strong><br><small>pnag0009@student.monash.edu</small></td>
+        <td><strong>🧑‍💼 Omar</strong><br><small>osal0004@student.monash.edu</small></td>
+        <td><strong>🧑‍💼 Naveen</strong><br><small>nsel0009@student.monash.edu</small></td>
       </tr>
       <tr>
-        <td><strong>Omar</strong><br><small>osal0004@student.monash.edu</small></td>
+        <td><strong>🏗️ Danniel</strong><br><small>dyou0009@student.monash.edu</small></td>
         <td></td>
       </tr>
     </table>
@@ -178,12 +189,12 @@ There are four GitHub Actions Workflows to manage application deployment.
     <h3>Team Rhino</h3>
     <table align="center" style="border-collapse:collapse;">
       <tr>
-        <td><strong>Devan</strong><br><small>dfed0003@student.monash.edu</small></td>
-        <td><strong>Meng</strong><br><small>hsia0003@student.monash.edu</small></td>
+        <td><strong>🚂 Aden</strong><br><small>atra0066@student.monash.edu</small></td>
+        <td><strong>🚂 Will Richter</strong><br><small>wric0006@student.monash.edu</small></td>
       </tr>
       <tr>
-        <td><strong>Aden</strong><br><small>atra0066@student.monash.edu</small></td>
-        <td><strong>Will Richter</strong><br><small>wric0006@student.monash.edu</small></td>
+        <td><strong>🏗️ Devan</strong><br><small>dfed0003@student.monash.edu</small></td>
+        <td><strong>🧑‍💼 Meng</strong><br><small>hsia0003@student.monash.edu</small></td>
       </tr>
     </table>
   </div>
@@ -193,15 +204,15 @@ There are four GitHub Actions Workflows to manage application deployment.
     <h3>Team Pogo</h3>
     <table align="center" style="border-collapse:collapse;">
       <tr>
-        <td><strong>Cameron</strong><br><small>cameronhumphreys77@gmail.com</small></td>
-        <td><strong>Anika</strong><br><small>akam0020@student.monash.edu</small></td>
+        <td><strong>🚂 Cameron</strong><br><small>cameronhumphreys77@gmail.com</small></td>
+        <td><strong>🚂 Anika</strong><br><small>akam0020@student.monash.edu</small></td>
       </tr>
       <tr>
-        <td><strong>Tinesia</strong><br><small>tyuu0023@student.monash.edu</small></td>
-        <td><strong>Derek</strong><br><small>derek.jcao@gmail.com</small></td>
+        <td><strong>🧑‍💼 Tinesia</strong><br><small>tyuu0023@student.monash.edu</small></td>
+        <td><strong>🧑‍💼 Derek</strong><br><small>derek.jcao@gmail.com</small></td>
       </tr>
       <tr>
-        <td><strong>Daniel Loh</strong><br><small>dloh0003@student.monash.edu</small></td>
+        <td><strong>🏗️ Daniel Loh</strong><br><small>dloh0003@student.monash.edu</small></td>
         <td></td>
       </tr>
     </table>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Beastly Brawl Showdown is a web-based role-playing game where players battle eac
 
 - **Production:** https://www.beastlybrawl.app/ (active during milestone presentations)
 - **Test:** https://www.beastlybrawl-test.app/ (generally up 24/7)
-- **Local:** See instructions above
+- **Local:** See instructions below
 
 ---
 
@@ -152,27 +152,61 @@ There are four GitHub Actions Workflows to manage application deployment.
 
 ## Meet The Team!
 
-### System Architects
+<div align="center">
 
-- Devan (dfed0003@student.monash.edu)
-- Danniel (dyou0009@student.monash.edu)
-- Daniel Loh (dloh0003@student.monash.edu)
+  <div style="display:inline-block; width:280px; margin:20px; vertical-align:top; text-align:center;">
+    <img src="https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/character/CHARMER_COBRA.png" alt="Team Cobra" width="200" />
+    <h3>Team Cobra</h3>
+    <table align="center" style="border-collapse:collapse;">
+      <tr>
+        <td><strong>Naveen</strong><br><small>nsel0009@student.monash.edu</small></td>
+        <td><strong>Huu Nguyen</strong><br><small>hngu0187@student.monash.edu</small></td>
+      </tr>
+      <tr>
+        <td><strong>Danniel</strong><br><small>dyou0009@student.monash.edu</small></td>
+        <td><strong>Luna</strong><br><small>pnag0009@student.monash.edu</small></td>
+      </tr>
+      <tr>
+        <td><strong>Omar</strong><br><small>osal0004@student.monash.edu</small></td>
+        <td></td>
+      </tr>
+    </table>
+  </div>
 
-### Product Managers
+  <div style="display:inline-block; width:280px; margin:20px; vertical-align:top; text-align:center;">
+    <img src="https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/character/ROCKY_RHINO.png" alt="Team Rhino" width="200" />
+    <h3>Team Rhino</h3>
+    <table align="center" style="border-collapse:collapse;">
+      <tr>
+        <td><strong>Devan</strong><br><small>dfed0003@student.monash.edu</small></td>
+        <td><strong>Meng</strong><br><small>hsia0003@student.monash.edu</small></td>
+      </tr>
+      <tr>
+        <td><strong>Aden</strong><br><small>atra0066@student.monash.edu</small></td>
+        <td><strong>Will Richter</strong><br><small>wric0006@student.monash.edu</small></td>
+      </tr>
+    </table>
+  </div>
 
-- Naveen (nsel0009@student.monash.edu)
-- Meng (hsia0003@student.monash.edu)
-- Tinesia (tyuu0023@student.monash.edu)
-- Derek (dcao0008@student.monash.edu)
-- Omar (osal0004@student.monash.edu)
+  <div style="display:inline-block; width:280px; margin:20px; vertical-align:top; text-align:center;">
+    <img src="https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/character/POISON_POGO.png" alt="Team Pogo" width="200" />
+    <h3>Team Pogo</h3>
+    <table align="center" style="border-collapse:collapse;">
+      <tr>
+        <td><strong>Cameron</strong><br><small>cameronhumphreys77@gmail.com</small></td>
+        <td><strong>Anika</strong><br><small>akam0020@student.monash.edu</small></td>
+      </tr>
+      <tr>
+        <td><strong>Tinesia</strong><br><small>tyuu0023@student.monash.edu</small></td>
+        <td><strong>Derek</strong><br><small>derek.jcao@gmail.com</small></td>
+      </tr>
+      <tr>
+        <td><strong>Daniel Loh</strong><br><small>dloh0003@student.monash.edu</small></td>
+        <td></td>
+      </tr>
+    </table>
+  </div>
 
-### Release Train Engineers
-
-- Aden (atra0066@student.monash.edu)
-- Will Richter (wric0006@student.monash.edu)
-- Luna (pnag0009@student.monash.edu)
-- Cameron (cameronhumphreys77@gmail.com)
-- Anika (akam0020@student.monash.edu)
-- Huu Nguyen (hngu0187@student.monash.edu)
+</div>
 
 ---

--- a/client/src/components/popups/ConsumablePickupPopup.tsx
+++ b/client/src/components/popups/ConsumablePickupPopup.tsx
@@ -1,0 +1,29 @@
+// ConsumablePickupPopup.tsx
+import React from "react";
+import { ConsumablePopup } from "./ConsumablePopup";
+import { ConsumableState } from "/types/single/itemState";
+
+interface ConsumablePickupPopupProps {
+  consumable: ConsumableState;
+  onTake: () => void; // put into backpack
+  onDrop: () => void; // discard
+}
+
+export const ConsumablePickupPopup = ({
+  consumable,
+  onTake,
+  onDrop,
+}: ConsumablePickupPopupProps) => {
+  // We reuse ConsumablePopup but override the button text/behaviour
+  return (
+    <ConsumablePopup
+      consumable={consumable}
+      isDisabled={false}
+      onClose={onDrop} // “BACK / DROP”
+      onConsume={onTake} // “CONSUME” button becomes “TAKE”
+      backText="DROP"
+      consumeText="TAKE"
+      confirmText="You found a consumable! What do you want to do?"
+    />
+  );
+};

--- a/client/src/components/popups/ConsumablePickupPopup.tsx
+++ b/client/src/components/popups/ConsumablePickupPopup.tsx
@@ -14,7 +14,6 @@ export const ConsumablePickupPopup = ({
   onTake,
   onDrop,
 }: ConsumablePickupPopupProps) => {
-  // We reuse ConsumablePopup but override the button text/behaviour
   return (
     <ConsumablePopup
       consumable={consumable}

--- a/client/src/components/popups/ConsumablePopup.tsx
+++ b/client/src/components/popups/ConsumablePopup.tsx
@@ -4,6 +4,7 @@ import { PopupAdventure } from "./PopupAdventure";
 import { ButtonGeneric } from "../buttons/ButtonGeneric";
 import { OutlineText } from "../texts/OutlineText";
 import { BlackText } from "../texts/BlackText";
+import { on } from "events";
 
 export interface ConsumableProp {
   consumable: ConsumableState;
@@ -58,12 +59,6 @@ export const ConsumablePopup = ({
         lg:h-[85%]
         sm:h-[75%]`;
 
-  const consume = () => {
-    console.log("CONSUME CLICKED");
-    onClose();
-    onConsume();
-  };
-
   //TODO: centre the rest of this poop
   //TODO: can't click
   return (
@@ -113,7 +108,7 @@ export const ConsumablePopup = ({
                 color="blue"
                 size="battle"
                 isDisabled={isDisabled}
-                onClick={consume}
+                onClick={onConsume}
               >
                 <div className="items-center">
                   <OutlineText size="choice-text">{consumeText}</OutlineText>

--- a/client/src/components/popups/ConsumablePopup.tsx
+++ b/client/src/components/popups/ConsumablePopup.tsx
@@ -1,7 +1,10 @@
+import React, { ReactNode, useState } from "react";
 import { ConsumableState } from "/types/single/itemState";
+import { PopupAdventure } from "./PopupAdventure";
 import { ButtonGeneric } from "../buttons/ButtonGeneric";
 import { OutlineText } from "../texts/OutlineText";
 import { BlackText } from "../texts/BlackText";
+import { on } from "events";
 
 export interface ConsumableProp {
   consumable: ConsumableState;

--- a/client/src/components/popups/ConsumablePopup.tsx
+++ b/client/src/components/popups/ConsumablePopup.tsx
@@ -10,6 +10,9 @@ export interface ConsumableProp {
   onClose: () => void;
   onConsume: () => void;
   isDisabled: boolean;
+  backText?: string;
+  consumeText?: string;
+  confirmText?: string;
 }
 
 export const ConsumablePopup = ({
@@ -17,6 +20,9 @@ export const ConsumablePopup = ({
   onClose,
   onConsume,
   isDisabled,
+  backText = "BACK",
+  consumeText = "CONSUME",
+  confirmText = "Are you sure you want to consume this?",
 }: ConsumableProp) => {
   const popupLayout = `z-100  items-center
         justify-center
@@ -93,16 +99,14 @@ export const ConsumablePopup = ({
                   {consumable.statDescription}
                 </OutlineText>
               </div>
-              <BlackText size="medium">
-                Are you sure you want to consume this?
-              </BlackText>
+              <BlackText size="medium">{confirmText}</BlackText>
             </div>
 
             {/* Buttons */}
             <div className="justify-center items-center flex lg:gap-5 sm:gap-10">
               <ButtonGeneric color="red" size="battle" onClick={onClose}>
                 <div className="items-center">
-                  <OutlineText size="choice-text">BACK</OutlineText>
+                  <OutlineText size="choice-text">{backText}</OutlineText>
                 </div>
               </ButtonGeneric>
               <ButtonGeneric
@@ -112,7 +116,7 @@ export const ConsumablePopup = ({
                 onClick={consume}
               >
                 <div className="items-center">
-                  <OutlineText size="choice-text">CONSUME</OutlineText>
+                  <OutlineText size="choice-text">{consumeText}</OutlineText>
                 </div>
               </ButtonGeneric>
             </div>

--- a/client/src/components/popups/ConsumablePopup.tsx
+++ b/client/src/components/popups/ConsumablePopup.tsx
@@ -1,10 +1,7 @@
-import React, { ReactNode, useState } from "react";
 import { ConsumableState } from "/types/single/itemState";
-import { PopupAdventure } from "./PopupAdventure";
 import { ButtonGeneric } from "../buttons/ButtonGeneric";
 import { OutlineText } from "../texts/OutlineText";
 import { BlackText } from "../texts/BlackText";
-import { on } from "events";
 
 export interface ConsumableProp {
   consumable: ConsumableState;

--- a/client/src/components/popups/EquipmentPickupPopup.tsx
+++ b/client/src/components/popups/EquipmentPickupPopup.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { EquipmentState } from "/types/single/itemState";
+import { EquipmentPopup } from "./EquipmentPopup";
+
+interface EquipmentPickupPopupProps {
+  equipment: EquipmentState;
+  onEquip: () => void;
+  onDrop: () => void;
+}
+
+export const EquipmentPickupPopup: React.FC<EquipmentPickupPopupProps> = ({
+  equipment,
+  onEquip,
+  onDrop,
+}) => {
+  return (
+    <EquipmentPopup
+      equipment={equipment}
+      onClose={onDrop}
+      onEquip={onEquip}
+      backText="DROP"
+      equipText="EQUIP"
+    />
+  );
+};

--- a/client/src/components/popups/EquipmentPopup.tsx
+++ b/client/src/components/popups/EquipmentPopup.tsx
@@ -8,9 +8,18 @@ import { BlackText } from "../texts/BlackText";
 export interface EquipmentProp {
   equipment: EquipmentState;
   onClose?: () => void;
+  onEquip?: () => void;
+  backText?: string;
+  equipText?: string;
 }
 
-export const EquipmentPopup = ({ equipment, onClose }: EquipmentProp) => {
+export const EquipmentPopup = ({
+  equipment,
+  onClose,
+  onEquip,
+  backText = "BACK",
+  equipText = "EQUIP",
+}: EquipmentProp) => {
   const popupLayout = `z-100  items-center
         justify-center
         box-border
@@ -88,9 +97,16 @@ export const EquipmentPopup = ({ equipment, onClose }: EquipmentProp) => {
             <div className="justify-center p-[1rem] items-center flex lg:gap-5 sm:gap-10">
               <ButtonGeneric color="red" size="battle" onClick={onClose}>
                 <div className="items-center">
-                  <OutlineText size="choice-text">BACK</OutlineText>
+                  <OutlineText size="choice-text">{backText}</OutlineText>
                 </div>
               </ButtonGeneric>
+              {onEquip && (
+                <ButtonGeneric color="blue" size="battle" onClick={onEquip}>
+                  <div className="items-center">
+                    <OutlineText size="choice-text">{equipText}</OutlineText>
+                  </div>
+                </ButtonGeneric>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/pages/Adventure/AdventureBattle.tsx
+++ b/client/src/pages/Adventure/AdventureBattle.tsx
@@ -1,7 +1,4 @@
-import {
-  MonsterIdentifier,
-  MonsterState,
-} from "../../../../types/single/monsterState";
+import { MonsterIdentifier } from "../../../../types/single/monsterState";
 import BattleMonsterPanel from "../../components/player-screen/BattleMonsterPanel";
 import DiceRollModal from "../Game/DiceRollModal";
 import { BattleFooter } from "../../components/cards/BattleFooter";
@@ -12,12 +9,14 @@ import React from "react";
 import socket from "../../socket";
 import { DialogueBox } from "../../components/cards/DialogueBox";
 import { option } from "../../../../types/composite/storyTypes";
+import { DialogueChoiceButton } from "../../components/buttons/DialogueChoiceButton";
 import { PopupClean } from "../../components/popups/PopupClean";
 import { OutlineText } from "../../components/texts/OutlineText";
 import { ButtonGeneric } from "../../components/buttons/ButtonGeneric";
 import { ChoicePopup } from "../../components/popups/ChoicePopup";
 import { FlowRouter } from "meteor/ostrio:flow-router-extra";
 import { StatChangePopup } from "../../components/popups/statChangePopup";
+import { MonsterState } from "../../../../types/single/monsterState";
 import MonsterDisplay from "../../components/player-screen/MonsterDisplay";
 import { LeavePopup } from "../../components/popups/AdventureLeavePopup";
 import { IconButton } from "../../components/buttons/IconButton";
@@ -25,10 +24,12 @@ import { AdventureInfoPanel } from "../../components/player-screen/AdventureInfo
 import { PlayerState } from "/types/single/playerState";
 import { MonsterInfoPopup } from "../../components/popups/MonsterInfoPopup";
 import { AdventureBagPopup } from "../../components/popups/AdventureBag";
-import { EquipmentState, ConsumableState } from "/types/single/itemState";
+import { EquipmentState } from "/types/single/itemState";
 import { EquipmentCard } from "../../components/cards/EquipmentCard";
 import { AdventureBattleHeader } from "../../components/player-screen/AdventureBattleHeader";
+import { ConsumablePopup } from "../../components/popups/ConsumablePopup";
 import { ConsumablePickupPopup } from "../../components/popups/ConsumablePickupPopup";
+import { ConsumableState } from "/types/single/itemState";
 import { EquipmentPickupPopup } from "../../components/popups/EquipmentPickupPopup";
 
 interface AdventureProps {

--- a/client/src/pages/Adventure/AdventureBattle.tsx
+++ b/client/src/pages/Adventure/AdventureBattle.tsx
@@ -77,6 +77,7 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
 
   const [statChange, setStatChange] = useState<string[] | null>(null);
   const [statusResult, setStatusResult] = useState<string[] | null>(null);
+  const [hasNewInventoryItem, setHasNewInventoryItem] = useState(false);
 
   //DICE
   const [showDiceModal, setShowDiceModal] = useState(false); // show dice modal | TODO: For future, use action animation ID instead of boolean to trigger animations
@@ -182,12 +183,14 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
       console.log("Received adventure_consumable:", data);
       setReceivingConsumable(data.consumable);
       setConsumableId(data.consumableId);
+      setHasNewInventoryItem(true);
     });
 
     socket.on("adventure_equipment", (data) => {
       console.log("Received adventure_equipment:", data);
       setReceivingEquipment(data.equipment);
       setEquipmentId(data.equipmentId);
+      setHasNewInventoryItem(true);
     });
 
     socket.on("adventure_equipment_full", (data) => {
@@ -438,14 +441,44 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
                   <ButtonGeneric
                     color={"ronchi"}
                     size={"backpack"}
-                    onClick={() => setViewingInventory(true)}
+                    onClick={() => {
+                      setViewingInventory(true);
+                      setHasNewInventoryItem(false);
+                    }}
                   >
-                    <img
-                      src={
-                        "https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/items/backpack.png"
-                      }
-                      className={"w-[80%] h-[80%] object-contain mx-auto"}
-                    ></img>
+                    <div
+                      style={{ position: "relative", display: "inline-block" }}
+                    >
+                      <img
+                        src={
+                          "https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/items/backpack.png"
+                        }
+                        className={"w-[90%] h-[90%] object-contain mx-auto"}
+                      />
+                      {hasNewInventoryItem && (
+                        <span
+                          className="
+                            absolute
+                            top-0
+                            right-0
+                            w-[36px] h-[36px]
+                            sm:w-[24px] sm:h-[24px]
+                            bg-red-600
+                            rounded-full
+                            flex items-center justify-center
+                            text-white
+                            text-[12px] sm:text-[16px]
+                            font-bold
+                            border-2 border-white
+                            pointer-events-none
+                            z-10
+                            select-none
+                          "
+                        >
+                          !
+                        </span>
+                      )}
+                    </div>
                   </ButtonGeneric>
                 </div>
               </div>
@@ -512,14 +545,41 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
                 <ButtonGeneric
                   color={"ronchi"}
                   size={"squaremedium"}
-                  onClick={() => setViewingInventory(true)}
+                  onClick={() => {
+                    setViewingInventory(true);
+                    setHasNewInventoryItem(false);
+                  }}
                 >
-                  <img
-                    src={
-                      "https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/items/backpack.png"
-                    }
-                    className={"w-[80%] h-[80%] object-contain mx-auto"}
-                  ></img>
+                  <div className="relative inline-block">
+                    <img
+                      src={
+                        "https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/items/backpack.png"
+                      }
+                      className="w-[80%] h-[80%] object-contain mx-auto"
+                    />
+                    {hasNewInventoryItem && (
+                      <span
+                        className="
+                        absolute
+                        -top-2 -right-2
+                        w-[22px] h-[22px]
+                        sm:w-[28px] sm:h-[28px]
+                        bg-red-600
+                        rounded-full
+                        flex items-center justify-center
+                        text-white
+                        text-[14px] sm:text-[18px]
+                        font-bold
+                        border-2 border-white
+                        pointer-events-none
+                        z-10
+                        select-none
+                      "
+                      >
+                        !
+                      </span>
+                    )}
+                  </div>
                 </ButtonGeneric>
               </div>
             </div>

--- a/client/src/pages/Adventure/AdventureBattle.tsx
+++ b/client/src/pages/Adventure/AdventureBattle.tsx
@@ -1,4 +1,7 @@
-import { MonsterIdentifier } from "../../../../types/single/monsterState";
+import {
+  MonsterIdentifier,
+  MonsterState,
+} from "../../../../types/single/monsterState";
 import BattleMonsterPanel from "../../components/player-screen/BattleMonsterPanel";
 import DiceRollModal from "../Game/DiceRollModal";
 import { BattleFooter } from "../../components/cards/BattleFooter";
@@ -9,14 +12,12 @@ import React from "react";
 import socket from "../../socket";
 import { DialogueBox } from "../../components/cards/DialogueBox";
 import { option } from "../../../../types/composite/storyTypes";
-import { DialogueChoiceButton } from "../../components/buttons/DialogueChoiceButton";
 import { PopupClean } from "../../components/popups/PopupClean";
 import { OutlineText } from "../../components/texts/OutlineText";
 import { ButtonGeneric } from "../../components/buttons/ButtonGeneric";
 import { ChoicePopup } from "../../components/popups/ChoicePopup";
 import { FlowRouter } from "meteor/ostrio:flow-router-extra";
 import { StatChangePopup } from "../../components/popups/statChangePopup";
-import { MonsterState } from "../../../../types/single/monsterState";
 import MonsterDisplay from "../../components/player-screen/MonsterDisplay";
 import { LeavePopup } from "../../components/popups/AdventureLeavePopup";
 import { IconButton } from "../../components/buttons/IconButton";
@@ -24,12 +25,10 @@ import { AdventureInfoPanel } from "../../components/player-screen/AdventureInfo
 import { PlayerState } from "/types/single/playerState";
 import { MonsterInfoPopup } from "../../components/popups/MonsterInfoPopup";
 import { AdventureBagPopup } from "../../components/popups/AdventureBag";
-import { EquipmentState } from "/types/single/itemState";
+import { EquipmentState, ConsumableState } from "/types/single/itemState";
 import { EquipmentCard } from "../../components/cards/EquipmentCard";
 import { AdventureBattleHeader } from "../../components/player-screen/AdventureBattleHeader";
-import { ConsumablePopup } from "../../components/popups/ConsumablePopup";
 import { ConsumablePickupPopup } from "../../components/popups/ConsumablePickupPopup";
-import { ConsumableState } from "/types/single/itemState";
 import { EquipmentPickupPopup } from "../../components/popups/EquipmentPickupPopup";
 
 interface AdventureProps {

--- a/client/src/pages/Adventure/AdventureBattle.tsx
+++ b/client/src/pages/Adventure/AdventureBattle.tsx
@@ -27,6 +27,10 @@ import { AdventureBagPopup } from "../../components/popups/AdventureBag";
 import { EquipmentState } from "/types/single/itemState";
 import { EquipmentCard } from "../../components/cards/EquipmentCard";
 import { AdventureBattleHeader } from "../../components/player-screen/AdventureBattleHeader";
+import { ConsumablePopup } from "../../components/popups/ConsumablePopup";
+import { ConsumablePickupPopup } from "../../components/popups/ConsumablePickupPopup";
+import { ConsumableState } from "/types/single/itemState";
+import { EquipmentPickupPopup } from "../../components/popups/EquipmentPickupPopup";
 
 interface AdventureProps {
   //so i am adding this without actually knowing why just trust the process
@@ -56,13 +60,11 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
   const [viewingInfo, setViewingInfo] = useState<Boolean>(false);
   const [viewingEnemyInfo, setViewingEnemyInfo] = useState<Boolean>(false);
   const [viewingInventory, setViewingInventory] = useState<Boolean>(false);
-  const [receivingConsumable, setReceivingConsumable] = useState<string | null>(
-    null
-  );
+  const [receivingConsumable, setReceivingConsumable] =
+    useState<ConsumableState | null>(null);
   const [consumableId, setConsumableId] = useState<string | null>(null);
-  const [receivingEquipment, setReceivingEquipment] = useState<string | null>(
-    null
-  );
+  const [receivingEquipment, setReceivingEquipment] =
+    useState<EquipmentState | null>(null);
   const [equipmentId, setEquipmentId] = useState<string | null>(null);
   const [equipmentInventoryFull, setEquipmentInventoryFull] = useState(false);
   const [currentEquipment, setCurrentEquipment] = useState<EquipmentState[]>(
@@ -178,13 +180,13 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
 
     socket.on("adventure_consumable", (data) => {
       console.log("Received adventure_consumable:", data);
-      setReceivingConsumable(data.name);
+      setReceivingConsumable(data.consumable);
       setConsumableId(data.consumableId);
     });
 
     socket.on("adventure_equipment", (data) => {
       console.log("Received adventure_equipment:", data);
-      setReceivingEquipment(data.name);
+      setReceivingEquipment(data.equipment);
       setEquipmentId(data.equipmentId);
     });
 
@@ -241,89 +243,49 @@ const AdventureBattle: React.FC<AdventureProps> = ({ levelMonster }) => {
           ></MonsterInfoPopup>
         )}
         {viewingInventory && (
-          <MonsterInfoPopup
+          <AdventureBagPopup
             playerState={playerState}
             onClose={() => setViewingInventory(false)}
             inBattle={battleState !== null}
-          ></MonsterInfoPopup>
+          ></AdventureBagPopup>
         )}
         {receivingConsumable && (
-          <div>
-            <PopupClean>
-              <div className="flex flex-col justify-around items-center">
-                <OutlineText size="extraLarge">
-                  {receivingConsumable}
-                </OutlineText>
-                <div className="flex flex-row justify-between gap-x-[3rem] items-center">
-                  <ButtonGeneric
-                    size="battle"
-                    color="blue"
-                    onClick={() => {
-                      setReceivingConsumable(null);
-                      setConsumableId(null);
-                      socket.emit("adventure_take_consumable", {
-                        consumableId,
-                        stage,
-                      });
-                    }}
-                  >
-                    TAKE!
-                  </ButtonGeneric>
-                  <ButtonGeneric
-                    size="battle"
-                    color="red"
-                    onClick={() => {
-                      setReceivingConsumable(null);
-                      setConsumableId(null);
-                      socket.emit("adventure_next", { stage });
-                    }}
-                  >
-                    DROP
-                  </ButtonGeneric>
-                </div>
-              </div>
-            </PopupClean>
-          </div>
+          <ConsumablePickupPopup
+            consumable={receivingConsumable}
+            onTake={() => {
+              setReceivingConsumable(null);
+              setConsumableId(null);
+              socket.emit("adventure_take_consumable", {
+                consumableId,
+                stage,
+              });
+            }}
+            onDrop={() => {
+              setReceivingConsumable(null);
+              setConsumableId(null);
+              socket.emit("adventure_next", { stage });
+            }}
+          />
         )}
         {receivingEquipment &&
           !equipmentInventoryFull &&
           !incomingEquipment && (
-            <div>
-              <PopupClean>
-                <div className="flex flex-col justify-around items-center">
-                  <OutlineText size="extraLarge">
-                    {receivingEquipment}
-                  </OutlineText>
-                  <div className="flex flex-row justify-between gap-x-[3rem] items-center">
-                    <ButtonGeneric
-                      size="battle"
-                      color="blue"
-                      onClick={() => {
-                        setReceivingEquipment(null);
-                        setEquipmentId(null);
-                        socket.emit("adventure_take_equipment", {
-                          equipmentId,
-                          stage,
-                        });
-                      }}
-                    >
-                      EQUIP!
-                    </ButtonGeneric>
-                    <ButtonGeneric
-                      size="battle"
-                      color="red"
-                      onClick={() => {
-                        setReceivingEquipment(null);
-                        setEquipmentId(null);
-                        socket.emit("adventure_next", { stage });
-                      }}
-                    >
-                      DROP
-                    </ButtonGeneric>
-                  </div>
-                </div>
-              </PopupClean>
-            </div>
+            <EquipmentPickupPopup
+              equipment={receivingEquipment}
+              onEquip={() => {
+                setReceivingEquipment(null);
+                setEquipmentId(null);
+                socket.emit("adventure_take_equipment", {
+                  equipmentId,
+                  stage,
+                });
+              }}
+              onDrop={() => {
+                setReceivingEquipment(null);
+                setEquipmentId(null);
+                socket.emit("adventure_next", { stage });
+              }}
+            />
           )}
         {equipmentInventoryFull && incomingEquipment && (
           <PopupClean>

--- a/server/src/model/game/consumables/storyItem/slimeFriend.ts
+++ b/server/src/model/game/consumables/storyItem/slimeFriend.ts
@@ -21,7 +21,7 @@ export class SlimeFriend extends StoryItem {
   }
 
   public getImageString(): string {
-    return "https://spaces-bbs.syd1.cdn.digitaloceanspaces.com/assets/character/SLIME.png";
+    return "SLIME";
   }
 
   public consume(player: Player): void {

--- a/server/src/socket/adventureModeHandler.ts
+++ b/server/src/socket/adventureModeHandler.ts
@@ -4,24 +4,15 @@ import { Adventure } from "../model/game/adventure";
 import { Player } from "../model/game/player";
 import { MonsterIdentifier } from "/types/single/monsterState";
 import { Battle } from "../model/game/battle";
-import { ActionIdentifier, ActionState } from "/types/single/actionState";
 import { loadStage } from "../model/adventure/stageLoader";
 import { resolveOutcome } from "../model/adventure/storyResolver";
 import { storyOutcomes, storyStruct } from "/types/composite/storyTypes";
-import { NullAction } from "../model/game/action/null";
 import { getMonster } from "../model/game/monster/monsterMap";
-import { Action } from "../model/game/action/action";
-import { AttackAction } from "../model/game/action/attack";
 import { ConsumableState } from "/types/single/itemState";
 import { ConsumeAction } from "../model/game/action/consume";
 import { createEquipment } from "../model/adventure/factories/equipmentFactory";
 import { createConsumable } from "../model/adventure/factories/consumableFactory";
-import { DamageHeal } from "../model/game/status/damageHeal";
-import { Poison } from "../model/game/status/poison";
-import { Stun } from "../model/game/status/stun";
-import { SlimeSubstance } from "../model/game/consumables/slimeSubstance";
 import { StoryItem } from "../model/game/consumables/storyItem/storyItem";
-import { SlimeBoost } from "../model/game/status/slimeBoost";
 
 export const adventureModeHandler = (io: Server, socket: Socket) => {
   // Monster selection and adventure start

--- a/server/src/socket/adventureModeHandler.ts
+++ b/server/src/socket/adventureModeHandler.ts
@@ -4,15 +4,24 @@ import { Adventure } from "../model/game/adventure";
 import { Player } from "../model/game/player";
 import { MonsterIdentifier } from "/types/single/monsterState";
 import { Battle } from "../model/game/battle";
+import { ActionIdentifier, ActionState } from "/types/single/actionState";
 import { loadStage } from "../model/adventure/stageLoader";
 import { resolveOutcome } from "../model/adventure/storyResolver";
 import { storyOutcomes, storyStruct } from "/types/composite/storyTypes";
+import { NullAction } from "../model/game/action/null";
 import { getMonster } from "../model/game/monster/monsterMap";
+import { Action } from "../model/game/action/action";
+import { AttackAction } from "../model/game/action/attack";
 import { ConsumableState } from "/types/single/itemState";
 import { ConsumeAction } from "../model/game/action/consume";
 import { createEquipment } from "../model/adventure/factories/equipmentFactory";
 import { createConsumable } from "../model/adventure/factories/consumableFactory";
+import { DamageHeal } from "../model/game/status/damageHeal";
+import { Poison } from "../model/game/status/poison";
+import { Stun } from "../model/game/status/stun";
+import { SlimeSubstance } from "../model/game/consumables/slimeSubstance";
 import { StoryItem } from "../model/game/consumables/storyItem/storyItem";
+import { SlimeBoost } from "../model/game/status/slimeBoost";
 
 export const adventureModeHandler = (io: Server, socket: Socket) => {
   // Monster selection and adventure start


### PR DESCRIPTION
# Description

- MonsterInfoPopup -> AdventureBagPopup, wrong popup for backpack within a battle 
- Equipment and Consumable popups now show full info to player before they add it to their backpack
- Backpack displays a notification when a new item has been added. Notification is removed when backpack is opened
- Slight uplift to README file, added team monsters

<img width="350" height="350" alt="image" src="https://github.com/user-attachments/assets/ba54f5ce-5d95-4ac1-9d13-e18dd86344a6" />
<img width="313" height="203" alt="image" src="https://github.com/user-attachments/assets/99824c98-2b68-4dc2-9b49-1e1b416d1e21" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] End-to-end tests w/ Playwright
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] CI Pipeline
- [x] Manual Testing (please describe if checked):
- [ ] N/A

# Checklist (only check off the applicable):

- [x] **IMPORTANT: Have you ran the `Test - Startup Droplet & Deploy Game` GitHub Actions Workflow on your branch OR waited for the automatic trigger of the `Test - Startup Droplet & Deploy Game` GitHub Actions Workflow to complete after making the PR or completing any PR updates? Has it passed? Once it passed have you went on https://beastlybrawl-test.app and verified your changes have been successfully implemented and works?**
  > Reviewers, you might need to retrigger the workflow manually if another PR or someone else has ran the workflow after the PR was created to test the changes made on the PR.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
