### PR TITLE
3013: fixed dice roll not showing up bug

### DIFF
--- a/server/src/socket/battle/startBattleHandler.ts
+++ b/server/src/socket/battle/startBattleHandler.ts
@@ -112,10 +112,6 @@ export default function proceedBattleTurn(
         action.prepare(player2, player1);
       });
 
-      // Animations, For the future, we need to handle animations in a more centralised manner with no hard coding.
-      // Handles the dice roll - For now, typecasting to send the damage so dice can roll it
-      // TODO: For the future, actions should trigger their own animations themselves. Perhaps add a feature that emits animation type and let the
-      // battle screen handle the type of animation to show
       player1.getActions().forEach((action) => {
         const animationInfo = action.prepareAnimation();
         const animationType = animationInfo[0];
@@ -126,7 +122,7 @@ export default function proceedBattleTurn(
 
       player2.getActions().forEach((action) => {
         const animationInfo = action.prepareAnimation();
-        const animationType = animationInfo[1];
+        const animationType = animationInfo[0];
         const diceRollNumber = animationInfo[1];
 
         console.log(`ADV: Animation P2 - ${animationType}, ${diceRollNumber}`);


### PR DESCRIPTION
# Description

Animation issue with dice roll for player 2. Should now show dice rolls for both players.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] End-to-end tests w/ Playwright
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] CI Pipeline
- [X] Manual Testing (please describe if checked):
- [ ] N/A

# Checklist (only check off the applicable):

- [ ] **IMPORTANT: Have you ran the `Test - Startup Droplet & Deploy Game` GitHub Actions Workflow on your branch OR waited for the automatic trigger of the `Test - Startup Droplet & Deploy Game` GitHub Actions Workflow to complete after making the PR or completing any PR updates? Has it passed? Once it passed have you went on https://beastlybrawl-test.app and verified your changes have been successfully implemented and works?**
  > Reviewers, you might need to retrigger the workflow manually if another PR or someone else has ran the workflow after the PR was created to test the changes made on the PR.
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
